### PR TITLE
Handle __MACOSX

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -196,6 +196,9 @@ func NewScannerFromZipReader(zipReader *zip.Reader, options *ReadShapefileOption
 	var shxFiles []*zip.File
 	var shpFiles []*zip.File
 	for _, zipFile := range zipReader.File {
+		if isMacOSXPath(zipFile.Name) {
+			continue
+		}
 		switch strings.ToLower(path.Ext(zipFile.Name)) {
 		case ".dbf":
 			dbfFiles = append(dbfFiles, zipFile)

--- a/shapefile.go
+++ b/shapefile.go
@@ -351,6 +351,9 @@ func ReadZipReader(zipReader *zip.Reader, options *ReadShapefileOptions) (*Shape
 	var shxFiles []*zip.File
 	var shpFiles []*zip.File
 	for _, zipFile := range zipReader.File {
+		if isMacOSXPath(zipFile.Name) {
+			continue
+		}
 		switch strings.ToLower(filepath.Ext(zipFile.Name)) {
 		case ".dbf":
 			dbfFiles = append(dbfFiles, zipFile)

--- a/util.go
+++ b/util.go
@@ -1,0 +1,17 @@
+package shapefile
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func isMacOSXPath(p string) bool {
+	dir, _ := filepath.Split(p)
+	pathElements := strings.Split(dir, string(filepath.Separator))
+	for _, elem := range pathElements {
+		if elem == "__MACOSX" {
+			return true
+		}
+	}
+	return false
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,29 @@
+package shapefile
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestIsMACOSX(t *testing.T) {
+	type testCase struct {
+		path     string
+		expected bool
+	}
+	testCases := []testCase{
+		{"__MACOSX/dir/._test.shp", true},
+		{"dir/__MACOSX/._test.shp", true},
+		{"dir/__MACOSX/dir/._test.shp", true},
+		{"dir/__MACOSX/dir/__MACOSX/._test.shp", true},
+		{"dir/._test.shp", false},
+		{"dir/ABC__MACOSX", false},
+		{"dir/ABC__MACOSX/._test.shp", false},
+		{"dir/._test.shp.__MACOSX", false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.path, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isMacOSXPath(tc.path))
+		})
+	}
+}


### PR DESCRIPTION
Hi, thanks for the library

Theres an issue with zips compressed on macos. 
Essentially zips on Macs include a __MACOSX dir with pointers to all the files, this causes the numerical checks for number of file types by extension to always be >1.

I've fixed the issue