### PR TITLE
Fix: Prevent panic on scanner initialization error

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -343,6 +343,7 @@ func NewScanner(
 			scanner, err := NewScannerSHP(reader, sizes[".shp"], options.SHP)
 			if err != nil {
 				errSHP = fmt.Errorf("NewScannerSHP: %w", err)
+				return
 			}
 			scannerSHP = scanner
 		}
@@ -354,6 +355,7 @@ func NewScanner(
 			scanner, err := NewScannerDBF(reader, options.DBF)
 			if err != nil {
 				errDBF = fmt.Errorf("NewScannerDBF: %w", err)
+				return
 			}
 			scannerDBF = scanner
 			estimatedDBF = (sizes[".dbf"] - dbfHeaderLength) / int64(scanner.header.RecordSize)
@@ -366,6 +368,7 @@ func NewScanner(
 			scanner, err := NewScannerSHX(reader, sizes[".shx"])
 			if err != nil {
 				errSHX = fmt.Errorf("NewScannerSHX: %w", err)
+				return
 			}
 			scannerSHX = scanner
 			estimatedSHX = (sizes[".shx"] - headerSize) / 8


### PR DESCRIPTION
hi @twpayne thanks for the lib
but there is issue on scanner when dbf error it cause panic.

## Changes
- Add early returns in NewScanner goroutines to prevent execution continuation after errors
- Fix panic in NewScannerDBF where nil scanner header was accessed on error
- Ensure consistent error handling across SHP, DBF, and SHX scanner initialization

### How to reproduce:
- i try parsing shapefile with invalid dbf file, for example i use csv file then change it into .dbf just to test it when i upload invalid dbf file

<img width="1600" height="762" alt="image" src="https://github.com/user-attachments/assets/60988966-7ae3-45f6-8508-cd473c2e1b06" />
